### PR TITLE
Several Class instances unsubscribe fix

### DIFF
--- a/projects/ngx-destroy-subscribers/src/lib/decorator.ts
+++ b/projects/ngx-destroy-subscribers/src/lib/decorator.ts
@@ -1,44 +1,54 @@
 import { Unsubscribable } from 'rxjs';
 import 'reflect-metadata';
 
+export interface InstanceSubscriptionWithInstance {
+  instance: any;
+  subscription: Unsubscribable;
+}
+
 export function DestroySubscribers(params?) {
-  
+
   return function (target) {
     params = {
       destroyFunc: 'ngOnDestroy',
       ...params
     };
-    const unsubscribableLike: {subscriptions: Unsubscribable[], unsubscribe: () => void} = {
+    const unsubscribableLike: {subscriptions: InstanceSubscriptionWithInstance[], unsubscribe: () => void} = {
       subscriptions: [],
       unsubscribe,
     };
     const subscriber: string = Reflect.getMetadata('subscription:name', target.prototype, 'subscriber');
-  
+
     Object.defineProperty(target.prototype, subscriber || 'subscriber', {
       get: () => unsubscribableLike,
-      set: subscription => unsubscribableLike.subscriptions.push(subscription),
+      set: subscription => unsubscribableLike.subscriptions.push({ subscription, instance: this}),
     });
-  
+
     if (typeof target.prototype[params.destroyFunc] !== 'function') {
       throw new Error(`${target.prototype.constructor.name} must implement ${params.destroyFunc}() lifecycle hook`);
     }
-  
+
     target.prototype[params.destroyFunc] = ngOnDestroyDecorator(target.prototype[params.destroyFunc]);
-  
+
     function ngOnDestroyDecorator(f) {
       return function () {
-        unsubscribe();
-        return f.apply(this, arguments);
+        unsubscribe.call(this);
+        return f.apply(target, arguments);
       };
     }
-  
+
     function unsubscribe() {
+      const subscriptionsWithInstances = unsubscribableLike.subscriptions;
+      const escapedSubscriptions = subscriptionsWithInstances.filter(
+        (sub) => sub && typeof sub.subscription.unsubscribe === 'function'
+      );
+      const currentSubscriptions = escapedSubscriptions.filter((sub) => sub.instance === this);
       do {
-        const sub: Unsubscribable = unsubscribableLike.subscriptions.shift();
-        if ( sub && typeof sub.unsubscribe === 'function') { sub.unsubscribe(); }
-      } while (unsubscribableLike.subscriptions.length);
+        const {subscription} = currentSubscriptions.shift();
+        subscription.unsubscribe()
+      } while (currentSubscriptions.length);
     }
-  
+
     return target;
   };
 }

--- a/projects/ngx-destroy-subscribers/src/lib/decorator.ts
+++ b/projects/ngx-destroy-subscribers/src/lib/decorator.ts
@@ -42,15 +42,9 @@ export function DestroySubscribers(params?) {
     }
 
     function unsubscribe() {
-      const subscriptionsWithInstances = unsubscribableLike.subscriptions;
-      const escapedSubscriptions = subscriptionsWithInstances.filter(
-        (sub) => sub && typeof sub.subscription.unsubscribe === 'function'
-      );
-      const currentSubscriptions = escapedSubscriptions.filter((sub) => sub.instance === this);
-      do {
-        const {subscription} = currentSubscriptions.shift();
-        subscription.unsubscribe()
-      } while (currentSubscriptions.length);
+      const subscriptions = unsubscribableLike.subscriptions.filter(sub => sub && typeof sub.subscription.unsubscribe === 'function');
+      const componentInstanceSubscriptions = subscriptions.filter(sub => sub.instance === this);
+      componentInstanceSubscriptions.forEach(({subscription}) => subscription.unsubscribe());
     }
 
     return target;

--- a/projects/ngx-destroy-subscribers/src/lib/decorator.ts
+++ b/projects/ngx-destroy-subscribers/src/lib/decorator.ts
@@ -37,7 +37,7 @@ export function DestroySubscribers(params?) {
     function ngOnDestroyDecorator(f) {
       return function () {
         unsubscribe.call(this);
-        return f.apply(target, arguments);
+        return f.apply(this, arguments);
       };
     }
 

--- a/projects/ngx-destroy-subscribers/src/lib/decorator.ts
+++ b/projects/ngx-destroy-subscribers/src/lib/decorator.ts
@@ -21,10 +21,10 @@ export function DestroySubscribers(params?) {
 
     Object.defineProperty(target.prototype, subscriber || 'subscriber', {
       get: function () {
-        return { unsubscribe: unsubscribe.bind(this) }
+        return { unsubscribe: unsubscribe.bind(this) };
       },
       set: function (subscription) {
-        unsubscribableLike.subscriptions.push({ subscription, instance: this})
+        unsubscribableLike.subscriptions.push({ subscription, instance: this});
       },
     });
 

--- a/projects/ngx-destroy-subscribers/src/lib/decorator.ts
+++ b/projects/ngx-destroy-subscribers/src/lib/decorator.ts
@@ -20,8 +20,12 @@ export function DestroySubscribers(params?) {
     const subscriber: string = Reflect.getMetadata('subscription:name', target.prototype, 'subscriber');
 
     Object.defineProperty(target.prototype, subscriber || 'subscriber', {
-      get: () => unsubscribableLike,
-      set: subscription => unsubscribableLike.subscriptions.push({ subscription, instance: this}),
+      get: function () {
+        return { unsubscribe: unsubscribe.bind(this) }
+      },
+      set: function (subscription) {
+        unsubscribableLike.subscriptions.push({ subscription, instance: this})
+      },
     });
 
     if (typeof target.prototype[params.destroyFunc] !== 'function') {


### PR DESCRIPTION
When we have several instances of decorated class, unsubscribe method destroys subscriptions for all instances. This changes fix it.